### PR TITLE
Fix byte file read error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 1.2 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fix reading views.cfg file on python3
 
 
 1.1 (2019-04-26)

--- a/plone/app/themingplugins/views/plugin.py
+++ b/plone/app/themingplugins/views/plugin.py
@@ -11,7 +11,7 @@ import logging
 import os.path
 import Products.Five.browser.metaconfigure
 import zope.browsermenu.metaconfigure
-from six.moves.configparser import SafeConfigParser
+from six.moves.configparser import ConfigParser
 
 EXTENSION = ".pt"
 VIEW_CONFIG_FILENAME = "views.cfg"
@@ -93,12 +93,12 @@ class ViewsPlugin(object):
                     logger.warn("Could not import %s" % layerName)
                     return
 
-            viewConfig = SafeConfigParser()
+            viewConfig = ConfigParser()
 
             if viewsDir.isFile(VIEW_CONFIG_FILENAME):
                 fp = viewsDir.openFile(VIEW_CONFIG_FILENAME)
                 try:
-                    viewConfig.readfp(fp)
+                    viewConfig.read_string(fp.read().decode())
                 finally:
                     try:
                         fp.close()


### PR DESCRIPTION
This PR is fixing a bug that prevents reading views.cfg file in modern py3 installation.

`plone.resource.directory.openFile` method (https://github.com/plone/plone.resource/blob/1d3d297d836b0e05f516331e9bbb69d2d31a4514/plone/resource/directory.py#L254) returns a file instance in read bytes mode but configparser expects an "iterable yielding Unicode strings" (https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.read_file)

It fixes a couple of deprecations too.
